### PR TITLE
New option and minor fix

### DIFF
--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -83,7 +83,7 @@ describe('Object to form data', () => {
                 baz: {
                     boolean: false
                 }
-            }, {}, formData);
+            }, {useBrackets: true}, formData);
 
             expect(formData.append).toHaveBeenCalledWith('foo', 'true');
             expect(formData.append).toHaveBeenCalledWith('bar', 'false');
@@ -103,7 +103,7 @@ describe('Object to form data', () => {
                     2,
                     3
                 ]
-            }, {}, formData);
+            }, {useBrackets: true}, formData);
 
             expect(formData.append).toHaveBeenCalledWith('foo', 'true');
             expect(formData.append).toHaveBeenCalledWith('bar', 'false');
@@ -111,6 +111,48 @@ describe('Object to form data', () => {
             expect(formData.append).toHaveBeenCalledWith('baz[1]', 2);
             expect(formData.append).toHaveBeenCalledWith('baz[2]', 3);
         });
+
+        it('will not show brackets', () => {
+
+            objectToFormData({
+                foo:[
+                    "bar",
+                    12,
+                    true,
+                ],
+                bar: null
+            }, {useBrackets: false}, formData);
+
+            expect(formData.append).toHaveBeenCalledWith('foo', 'bar');
+            expect(formData.append).toHaveBeenCalledWith('foo', 12);
+            expect(formData.append).toHaveBeenCalledWith('foo', 'true');
+            //expect(formData.append).to('foo', 'true');
+        })
+
+        it('will not show brackets with a nested object', () => {
+
+            objectToFormData({
+                foo:[
+                    "bar",
+                    12,
+                ],
+                baz: {
+                    "x": [5, 6],
+                    "y": {
+                        "a": [1, 2],
+                        "b": [3]
+                    }
+                }
+            }, {useBrackets: false}, formData);
+
+            expect(formData.append).toHaveBeenCalledWith('foo', 'bar');
+            expect(formData.append).toHaveBeenCalledWith('foo', 12);
+            expect(formData.append).toHaveBeenCalledWith('baz[x]', 5);
+            expect(formData.append).toHaveBeenCalledWith('baz[x]', 6);
+            expect(formData.append).toHaveBeenCalledWith('baz[y][a]', 1);
+            expect(formData.append).toHaveBeenCalledWith('baz[y][a]', 2);
+            expect(formData.append).toHaveBeenCalledWith('baz[y][b]', 3);
+        })
 
 
         it('will append array of objects', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,10 @@ const processData = (value: any, options: Options, formData: FormData, parent?: 
 
   if (isArray(value)) {
     value.forEach((item, index) => {
-      const computedKey = `${processedKey}[${options.arrayIndexes ? index : ''}]`;
+      let computedKey = processedKey;
+      if(options.useBrackets){
+        computedKey += `[${options.arrayIndexes ? index : ''}]`
+      }
       processData(item, options, formData, computedKey);
     });
     return;
@@ -62,6 +65,7 @@ const defaultOptions: Options = {
   arrayIndexes: true,
   excludeNull: true,
   useDotSeparator: false,
+  useBrackets: true
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,7 +68,7 @@ const defaultOptions: Options = {
 const objectToFormData = (payload: any, options: Partial<Options> = {}, formData: FormData = new FormData()) => {
   if (!payload) return formData;
 
-  options = Object.assign(defaultOptions, options);
+  options = Object.assign({}, defaultOptions, options);
 
   processData(payload, options as Options, formData);
 

--- a/src/models/Options.ts
+++ b/src/models/Options.ts
@@ -2,4 +2,5 @@ export default interface Options {
     arrayIndexes: boolean,
     excludeNull: boolean,
     useDotSeparator: boolean,
+    useBrackets: boolean
 };


### PR DESCRIPTION
Changes:
- Added a new option called `useBrackets` to enable or disable the generation of brackets `[]` in arrays. This is very useful because some web frameworks such as [Javalin](https://javalin.io/) parse the brackets as part of the key. 
    - For example, in Javalin if the body contained `foo[]="bar"` and `foo[]="baz"`: 
        instead of converting it to `{"foo": ['bar', 'baz']}`, it reads `{"foo[]": ['bar', 'baz']}`. By setting `{useBrackets: false}`, Javalin will read arrays correctly.

- Fix issue that caused `defaultOptions` values to be replaced with the values of the parameter `options` at `objectToFormData`.
    - For example:
        ```js
        objectToFormData({foo:['bar', 'baz']}, {}) //outputs: {foo[0]: 'bar', foo[1]: 'baz'}
        objectToFormData({foo:['bar', 'baz']}, {arrayIndexes: false}) //outputs: {foo[]: 'bar', foo[]: 'baz'}
        objectToFormData({foo:['bar', 'baz']}, {}) //outputs: {foo[]: 'bar', foo[]: 'baz'}
        ```
        The third line is the same as the first line, however the output is different because the defaultOptions were rewritten at the second line!